### PR TITLE
Custom fields for product data

### DIFF
--- a/classes/class-projects-admin.php
+++ b/classes/class-projects-admin.php
@@ -306,6 +306,33 @@ class Projects_Admin {
 						$html .= '<p class="description">' . $v['description'] . '</p>' . "\n";
 						$html .= '</td><tr/>' . "\n";
 						break;
+					case 'radio':
+						$field = '';
+
+						if( isset( $v['options'] ) && is_array( $v['options'] ) ){
+							foreach ( $v['options'] as $val => $option ){
+								$field .= '<label for="' . esc_attr( $v['name'] . '-' . $val ) . '"><input id="' . esc_attr( $v['name'] . '-' . $val ) . '" type="radio" name="' . esc_attr( $k ) . '" value="' . esc_attr( $val ) . '" ' . checked( $val, $data, false ) . ' / >'. $option . '</label>' . "\n";
+							}
+						}
+
+						$html .= '<tr valign="top"><th scope="row"><label>' . $v['name'] . '</label></th><td>' . $field . "\n";
+						$html .= '<p class="description">' . $v['description'] . '</p>' . "\n";
+						$html .= '</td><tr/>' . "\n";
+						break;
+					case 'select':
+						$field = '<select name="' . esc_attr( $k ) . '" id="' . esc_attr( $k ) . '" >'. "\n";
+
+						if( isset( $v['options'] ) && is_array( $v['options'] ) ){
+							foreach ( $v['options'] as $val => $option ){
+								$field .= '<option value="' . esc_attr( $val ) . '" ' . selected( $val, $data, false ) . '>'. $option .'</option>' . "\n";
+							}
+						}
+						$field .= '</select>'. "\n";
+
+						$html .= '<tr valign="top"><th scope="row"><label for="' . esc_attr( $k ) . '">' . $v['name'] . '</label></th><td>' . $field . "\n";
+						$html .= '<p class="description">' . $v['description'] . '</p>' . "\n";
+						$html .= '</td><tr/>' . "\n";		
+
 					default:
 						$field = apply_filters( 'projects_data_field_type_' . $v['type'], null, $k, $data, $v );
 						if( $field ) {


### PR DESCRIPTION
Allow custom fields to be built out by users. A sample select type could then be created via:

```
function gb_custom_fields( $fields ){
    $fields['select'] = array(
            'name'          => __( 'Select', 'projects' ),
            'description'   => __( 'Test a dropdown', 'projects' ),
            'type'          => 'select',
            'default'       => 'b',
            'section'       => 'info',
            'options'       => array( 'a' => 'Apple', 'b' => 'Bacon' )
        );
    return $fields;
}
add_filter( 'projects_custom_fields', 'gb_custom_fields' );`

function gb_select_field( $html, $k, $data, $v ){
    $html = '<select name="' . esc_attr( $k ) . '" id="' . esc_attr( $k ) . '" >'. "\n";

    if( isset( $v['options'] ) && is_array( $v['options'] ) ){
        foreach ( $v['options'] as $val => $option ){
            $html .= '<option value="' . esc_attr( $val ) . '" ' . selected( $val, $data, false ) . '>'. $option .'</option>' . "\n";
        }
    }
    $html .= '</select>'. "\n";
    return $html;
}
add_filter( 'projects_data_field_type_select', 'gb_select_field', 10, 4 );
```
