### PR TITLE
remove CPT icon from CSS in favor of menu_icon parameter in register_pos...

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,6 +1,3 @@
-#adminmenu #menu-posts-project .menu-icon-project div.wp-menu-image:before {
-  content: "\f322"; }
-
 .post-type-project.edit-php table.wp-list-table .column-image {
   width: 120px;
   text-align: center; }

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1,11 +1,6 @@
 // Imports
 @import 'mixins';
 
-// Icons
-#adminmenu #menu-posts-project .menu-icon-project div.wp-menu-image:before {
-	content: "\f322";
-}
-
 // Projects screen
 .post-type-project.edit-php {
 	table.wp-list-table {

--- a/classes/class-projects.php
+++ b/classes/class-projects.php
@@ -155,7 +155,7 @@ class Projects {
 										'excerpt'
 										),
 			'menu_position' 		=> 5,
-			'menu_icon' 			=> ''
+			'menu_icon' 			=> 'dashicons-portfolio'
 		);
 
 		$args = apply_filters( 'projects_register_post_type', $args );


### PR DESCRIPTION
...t_type()

With WP3.9 (I think this is the reason anyway), there's no need to add the CPT icon to the CSS. You can list the dashicon name as the menu_icon when registering the post type. This is doubly neat b/c then it can be changed by filtering the register post type params. 
