### PR TITLE
Better default URLs for Taxonomy

### DIFF
--- a/classes/class-projects-taxonomy.php
+++ b/classes/class-projects-taxonomy.php
@@ -89,7 +89,8 @@ class Projects_Taxonomy {
 			'show_admin_column' 	=> true,
 			'query_var' 			=> true,
 			'show_in_nav_menus' 	=> true,
-			'show_tagcloud' 		=> false
+			'show_tagcloud' 		=> false,
+			'rewrite'               => array( 'slug' => 'projects', 'with_front' => false )
 			);
 	} // End _get_default_args()
 


### PR DESCRIPTION
- Set ‘with_front’ to false
- default slug to /projects/category-name
