### PR TITLE
Fix "Undefined index: woo_projects_nonce" notice

### DIFF
--- a/classes/class-projects-admin.php
+++ b/classes/class-projects-admin.php
@@ -455,7 +455,7 @@ class Projects_Admin {
 		global $post, $messages;
 
 		// Verify
-		if ( ( get_post_type() != $this->post_type ) || ! wp_verify_nonce( $_POST['woo_' . $this->token . '_nonce'], plugin_basename( $this->dir ) ) ) {
+		if ( ( get_post_type() != $this->post_type ) || ! isset( $_POST['woo_' . $this->token . '_nonce'] ) || ! wp_verify_nonce( $_POST['woo_' . $this->token . '_nonce'], plugin_basename( $this->dir ) ) ) {
 			return $post_id;
 		}
 


### PR DESCRIPTION
Hey Guys,

WordPress throws undefined index notice when trashing and restoring posts from trash.

[Screenshot](http://d.pr/i/1hSDT)

Per [Smashing Mag](http://www.smashingmagazine.com/2011/10/04/create-custom-post-meta-boxes-wordpress/) and [this guy](http://wordpress.aspcode.net/view/63538464303732726667944/undefined-index-atnonce-in-custom-post-metabox), this is caused by not checking if the key in question ("woo_projects_nonce" here) is set before trying to use it to verify the nonce.

The change here resolves this issue on my local install.

Hope this is helpful.
