### PR TITLE
Fixes "Undefined index: woo_projects_nonce" notice

### DIFF
--- a/classes/class-projects-admin.php
+++ b/classes/class-projects-admin.php
@@ -455,7 +455,7 @@ class Projects_Admin {
 		global $post, $messages;
 
 		// Verify
-		if ( ( get_post_type() != $this->post_type ) || ! wp_verify_nonce( $_POST['woo_' . $this->token . '_nonce'], plugin_basename( $this->dir ) ) ) {
+		if ( ( get_post_type() != $this->post_type ) || ! isset( $_POST['woo_' . $this->token . '_nonce'] ) || ! wp_verify_nonce( $_POST['woo_' . $this->token . '_nonce'], plugin_basename( $this->dir ) ) ) {
 			return $post_id;
 		}
 


### PR DESCRIPTION
WordPress throws undefined index notice when saving post meta
