### PR TITLE
New filter: projects_archive_loop_columns_classes

### DIFF
--- a/templates/archive-project.php
+++ b/templates/archive-project.php
@@ -46,7 +46,7 @@ get_header( 'projects' ); ?>
 				do_action( 'projects_before_loop' );
 			?>
 
-			<div class="projects columns-<?php echo $projects_loop['columns']; ?>">
+			<div class="projects columns-<?php echo $projects_loop['columns']; apply_filters( 'projects_archive_loop_columns_classes', '' ); ?>">
 
 			<?php projects_project_loop_start(); ?>
 


### PR DESCRIPTION
To enable creating output like: `<div class="projects columns-2 nm-row">` without having to do this:

```
// https://docs.woothemes.com/document/change-the-number-of-project-columns-on-archives/
add_filter( 'projects_loop_columns', 'jk_projects_columns', 99 );
function jk_projects_columns( $cols ) {
    $cols = '2 nm-row';
    return $cols;
}
```
