### PR TITLE
Register 'projects-by-woothemes-archive-description' widget area

### DIFF
--- a/projects-core-functions.php
+++ b/projects-core-functions.php
@@ -413,6 +413,18 @@ function projects_category_image_flush_transient ( $post_id ) {
 add_action( 'save_post', 'projects_category_image_flush_transient' );
 
 /**
+  * Adds a widget area for above Projects Archive (below Projects Title, above Columns Loop)
+  */
+function projects_archive_description_widget() {
+	register_sidebar( array(
+		'name'          => __( 'Projects Archive Description', 'projects-by-woothemes' ),
+		'id'            => 'projects-by-woothemes-archive-description',
+		'description'   => __( 'Displays before columns loop on Projects Archive view', 'projects-by-woothemes' ),
+	) );
+}
+add_action( 'widgets_init', 'projects_archive_description_widget' );
+
+/**
  * Enqueue styles
  */
 function projects_script() {


### PR DESCRIPTION
Adds a widget area for above Projects Archive (below Projects Title, above Columns Loop)

<img width="355" alt="screenshot 2016-02-16 08 27 37" src="https://cloud.githubusercontent.com/assets/1812179/13078923/3ff000be-d487-11e5-95a0-fa63fc2c83f5.png">
