### PR TITLE
Render 'projects-by-woothemes-archive-description' widget area

### DIFF
--- a/templates/archive-project.php
+++ b/templates/archive-project.php
@@ -34,7 +34,11 @@ get_header( 'projects' ); ?>
 
 		<?php endif; ?>
 
-		<?php do_action( 'projects_archive_description' ); ?>
+		<?php
+  			do_action( 'projects_archive_description' );
+  			dynamic_sidebar( 'projects-by-woothemes-archive-description' );
+		?>
+
 
 		<?php if ( have_posts() ) : ?>
 


### PR DESCRIPTION
Example result of adding a text widget:
<img width="1298" alt="screenshot 2016-02-16 08 27 47" src="https://cloud.githubusercontent.com/assets/1812179/13078957/5aedeab6-d487-11e5-9402-bc82b5ff1087.png">
