### PR TITLE
Added REST API support

### DIFF
--- a/projects.php
+++ b/projects.php
@@ -177,7 +177,11 @@ final class Projects {
 										),
 			'menu_position' 		=> 5,
 			'menu_icon' 			=> 'dashicons-portfolio',
-			'show_in_rest' 			=> true
+			'show_in_rest' 			=> true,
+			'taxonomies' 			=> array(
+										'post_tag',
+										'category'
+									   )
 		);
 
 		$args = apply_filters( 'projects_register_post_type', $args );

--- a/projects.php
+++ b/projects.php
@@ -176,7 +176,8 @@ final class Projects {
 										'excerpt'
 										),
 			'menu_position' 		=> 5,
-			'menu_icon' 			=> 'dashicons-portfolio'
+			'menu_icon' 			=> 'dashicons-portfolio',
+			'show_in_rest' 			=> true
 		);
 
 		$args = apply_filters( 'projects_register_post_type', $args );


### PR DESCRIPTION
Not sure if it's useful in general but needed to access projects through the JSON API and gridsome. This requires the type to be explicitly set to show in the API. Not sure about backward compatibility.

Perhaps this should be made into an option in settings?

https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-rest-api-support-for-custom-content-types/

